### PR TITLE
fix: handle empty strings and nulls in args

### DIFF
--- a/src/tag.ts
+++ b/src/tag.ts
@@ -15,10 +15,6 @@ const argumentToParameters = (arg: any): string => {
   return '?';
 };
 
-const errorIfArgIsUndefined = (value: any) => {
-  if (value === undefined) throw Error('MySQL arguments cannot contain undefined');
-};
-
 class SQLStatement implements SQLTemplate {
   private statement: string = '';
   private arguments: QueryArg[] = [];
@@ -28,7 +24,9 @@ class SQLStatement implements SQLTemplate {
       .map(getUniqueValues) // if value is an array, remove dublicates in that array
       .reduce((acc, arg) => [...acc, ...(arg instanceof SQLStatement ? arg.values : [arg])], []) // extract and include args from SQLTemplates
       .flat();
-    this.arguments.forEach(errorIfArgIsUndefined);
+    if (this.arguments.some(arg => arg === undefined)) {
+      throw Error('MySQL arguments cannot contain undefined');
+    }
     const combined = zip(strings, args);
     this.statement = combined.reduce((statement: string, [s, a]: any) => {
       return `${statement}${s}${a instanceof SQLStatement ? a.statement : argumentToParameters(a)}`;

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -1,12 +1,12 @@
 'use strict';
 import { createListOfSqlParams } from '@src/util';
-import { SQLTemplate, Query } from './types';
+import { SQLTemplate, Query, QueryArg } from './types';
 import zip from 'lodash.zip';
 
-const getUniqueValues = (array: any[]) => (Array.isArray(array) ? [...new Set(array)] : array);
+const getUniqueValues = (value: any) => (Array.isArray(value) ? [...new Set(value)] : value);
 
 const argumentToParameters = (arg: any): string => {
-  if (!arg) {
+  if (arg === undefined) {
     return '';
   }
   if (Array.isArray(arg)) {
@@ -15,15 +15,20 @@ const argumentToParameters = (arg: any): string => {
   return '?';
 };
 
+const errorIfArgIsUndefined = (value: any) => {
+  if (value === undefined) throw Error('MySQL arguments cannot contain undefined');
+};
+
 class SQLStatement implements SQLTemplate {
   private statement: string = '';
-  private arguments: any[] = [];
+  private arguments: QueryArg[] = [];
 
-  constructor(strings: string[], args: any[]) {
+  constructor(strings: string[], args: QueryArg[]) {
     this.arguments = args
-      .map(getUniqueValues)
-      .reduce((acc, arg) => [...acc, ...(arg instanceof SQLStatement ? arg.values : [arg])], [])
+      .map(getUniqueValues) // if value is an array, remove dublicates in that array
+      .reduce((acc, arg) => [...acc, ...(arg instanceof SQLStatement ? arg.values : [arg])], []) // extract and include args from SQLTemplates
       .flat();
+    this.arguments.forEach(errorIfArgIsUndefined);
     const combined = zip(strings, args);
     this.statement = combined.reduce((statement: string, [s, a]: any) => {
       return `${statement}${s}${a instanceof SQLStatement ? a.statement : argumentToParameters(a)}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export type JSONObject = { [member: string]: JSONValue };
 export type JSONArray = Array<JSONValue>;
 export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
 
-export type QueryArg = JSONPrimitive | Date | Buffer | ArrayBuffer | JSONValue | QueryArg[] | undefined;
+export type QueryArg = JSONPrimitive | Date | Buffer | ArrayBuffer | JSONValue | QueryArg[];
 
 export type Query = [string] | [string, QueryArg[]];
 

--- a/test/unit/tag.test.ts
+++ b/test/unit/tag.test.ts
@@ -32,4 +32,22 @@ describe('sql template', () => {
       arguments: [1, 2, 3, 4, 'hello']
     });
   });
+
+  it(`should handle empty strings in args`, () => {
+    expect({ ...SQL`SELECT * FROM table WHERE value = ${''}` }).toEqual({
+      statement: `SELECT * FROM table WHERE value = ?`,
+      arguments: ['']
+    });
+  });
+
+  it(`should handle nulls in args`, () => {
+    expect({ ...SQL`INSERT INTO table SET value = ${null}` }).toEqual({
+      statement: `INSERT INTO table SET value = ?`,
+      arguments: [null]
+    });
+  });
+
+  it(`should throw Error when undefined in args`, () => {
+    expect(() => ({ ...SQL`INSERT INTO table SET value = ${undefined}`})).toThrowError('MySQL arguments cannot contain undefined');
+  });
 });


### PR DESCRIPTION
Now handles empty strings and nulls in args

Removed undefined as a valid QueryArg since what would be the appropriate value for an undefined arg? null or '' or some third option? It also conflicted massively with the way we handle args right now and would require some effort in a rewrite. 